### PR TITLE
Use copy instead on template for relying-party.xml

### DIFF
--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -292,7 +292,7 @@
     backup: yes
 
 - name: 'Set Shibboleth relying-party.xml'
-  template:
+  copy:
     src: 'assets/{{inventory_hostname}}/idp/conf/relying-party.xml'
     dest: '{{ shib_idp.home }}/conf/relying-party.xml'
     owner: root


### PR DESCRIPTION
Template converted to a copy to avoid issues with double braces being interpreted bu Ansible.