### PR TITLE
Only backup specified files rather than all fines in credentials

### DIFF
--- a/bootstrap-v4.sh
+++ b/bootstrap-v4.sh
@@ -278,7 +278,6 @@ function set_ansible_cfg_log_path {
 echo $ANSIBLE_CFG
   replace_property_nosp 'log_path=' "${ACTIVITY_LOG////\\/}" \
     $ANSIBLE_CFG
-echo "Done"
 }
 
 function set_update_idp_script_cd_path {
@@ -325,7 +324,6 @@ function run_ansible {
   pushd $LOCAL_REPO > /dev/null
   ansible-playbook -i ansible_hosts site_v4.yml --force-handlers --extra-var="install_base=$INSTALL_BASE"
   popd > /dev/null
-echo "Done"
 }
 
 function backup_shibboleth_credentials {
@@ -333,8 +331,15 @@ function backup_shibboleth_credentials {
     mkdir $CREDENTIAL_BACKUP_PATH
   fi
 
-  cp -R $SHIBBOLETH_IDP_INSTANCE/credentials/* $CREDENTIAL_BACKUP_PATH
-echo "Done"
+  cp -R $SHIBBOLETH_IDP_INSTANCE/credentials/idp-backchannel.crt $CREDENTIAL_BACKUP_PATH
+  cp -R $SHIBBOLETH_IDP_INSTANCE/credentials/idp-backchannel.p12 $CREDENTIAL_BACKUP_PATH
+  cp -R $SHIBBOLETH_IDP_INSTANCE/credentials/idp-encryption.crt $CREDENTIAL_BACKUP_PATH
+  cp -R $SHIBBOLETH_IDP_INSTANCE/credentials/idp-encryption.key $CREDENTIAL_BACKUP_PATH
+  cp -R $SHIBBOLETH_IDP_INSTANCE/credentials/idp-signing.crt $CREDENTIAL_BACKUP_PATH
+  cp -R $SHIBBOLETH_IDP_INSTANCE/credentials/idp-signing.key $CREDENTIAL_BACKUP_PATH
+  cp -R $SHIBBOLETH_IDP_INSTANCE/credentials/sealer.jks $CREDENTIAL_BACKUP_PATH
+  cp -R $SHIBBOLETH_IDP_INSTANCE/credentials/sealer.kver $CREDENTIAL_BACKUP_PATH
+  
 }
 
 function display_fr_idp_registration_link {
@@ -343,7 +348,6 @@ function display_fr_idp_registration_link {
   else
     echo "$FR_PROD_REG"
   fi
-echo "Done"
 }
 
 function display_completion_message {


### PR DESCRIPTION
This will ensure the secrets.properties is not overwritten.

resolves #16 