### PR TITLE
Move the creation of /var/log/shibboleth-idp to the start. 

### DIFF
--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -11,6 +11,14 @@
     group: jetty
     mode: 0750
 
+- name: 'Create IdP log directory'
+  file:
+    name: /var/log/shibboleth-idp
+    owner: jetty
+    group: jetty
+    mode: 0700
+    state: directory
+
 - name: 'Download Shibboleth IdP distribution'
   get_url:
     url: '{{ urls.shib_idp.url }}'
@@ -138,14 +146,6 @@
 
 - name: 'Re-run IdP install.sh to install aaf-shib-ext and IdP branding'
   shell: '{{ shib_idp.src_root }}/install-{{ download.shib_idp.version}}.sh'
-
-- name: 'Create IdP log directory'
-  file:
-    name: /var/log/shibboleth-idp
-    owner: jetty
-    group: jetty
-    mode: 0700
-    state: directory
 
 - name: 'Symlink IdP log directory'
   file:


### PR DESCRIPTION
Move the creation of /var/log/shibboleth-idp to the start. This ensures the Shibboleth IdP installer has location to link its
local log directory to.