### PR TITLE
Merge master back to develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Overview
 The AAF Shibboleth IdP Installer is designed to automate the install of version 4 for the [Shibboleth IdP](https://shibboleth.atlassian.net/wiki/spaces/IDP4/overview) on a dedicated with one of the following supported operating systems;
-* Rocky Linux 8
-* CentOS 7, 8 or Stream
-* RedHAT 7 or 8
-* ORACLE Linux 7 or 8
-* Ubuntu 20.04 (Focal Fossa)
+* Rocky Linux 8 or 9
+* CentOS 7, Stream 8 or Stream 9
+* RedHAT 7, 8 or 9
+* ORACLE Linux 7, 8 or 9
+* Ubuntu 20.04 (Focal Fossa) or 22.04 (Jammy Jellyfish)
 
 For a full set of documentation and guidance on upgrading from Shibboleth version 3 please refer to the [AAF IdPv4 Installer Knowledge base](https://aaf.freshdesk.com/support/solutions/articles/19000120020-shibboleth-idpv4-installer).
 
@@ -15,7 +15,7 @@ This software is actively being developed and maintained. It is ready for use in
 
 This version now enables the technical connection to eduGAIN, the global federation of federations.
 
-This release is for Shibboleth version 4.2.1 running on Jetty 9.4.46
+This release is for Shibboleth version 4.3.0 running on Jetty 9.4.50
 
 ## License
 Apache License Version 2.0, January 2004

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
-AAF_IdP_Installer_version= 1.5.0
-Shibboleth_IdP_version=    4.2.1
-Jetty_version=             9.4.46.v20220331
+AAF_IdP_Installer_version= 1.7.0
+Shibboleth_IdP_version=    4.3.0
+Jetty_version=             9.4.50.v20221201

--- a/assets/idp.example.edu.dist/idp/conf/edugain-attribute-filter.xml
+++ b/assets/idp.example.edu.dist/idp/conf/edugain-attribute-filter.xml
@@ -36,7 +36,7 @@
     <AttributeRule attributeID="givenName">
       <PermitValueRule xsi:type="ANY"/>
     </AttributeRule>
-    <AttributeRule attributeID="surname">
+    <AttributeRule attributeID="sn">
       <PermitValueRule xsi:type="ANY"/>
     </AttributeRule>
    

--- a/site_v4.yml
+++ b/site_v4.yml
@@ -28,12 +28,12 @@
     download:
       jetty:
         baseurl: "{{ aaf_binaries.baseurl }}/jetty"
-        version: 9.4.46.v20220331
-        sha256sum: ea018b057102181d26ce4e05d358fc7bbe07393cc6d0f80add78ec29c60d3ed9
+        version: 9.4.50.v20221201
+        sha256sum: e901ba564ed833829c36dea7e364c7379b743f1391048e9e1da6954e1874f1fd
       shib_idp:
         baseurl: "{{ aaf_binaries.baseurl }}/shibboleth"
-        version: 4.2.1
-        sha256sum: fa5e46d160f6b1bc50326c1a31627a05b5d0847b8f620d7f4c0251999b806474
+        version: 4.3.0
+        sha256sum: ef0b01af99c1364c2b6f88b06a697ed335a56e47528f9aa9dff123a7453325fa
       mysql_connector:
         baseurl: "{{ aaf_binaries.baseurl }}/jars/Connector-J"
         version: 8.0.28

--- a/tasks/idp.yml
+++ b/tasks/idp.yml
@@ -23,7 +23,7 @@
   get_url:
     url: '{{ urls.shib_idp.url }}'
     dest: '{{ idp_dist_archive_path }}'
-    sha256sum: '{{ download.shib_idp.sha256sum }}'
+    checksum: 'sha256:{{ download.shib_idp.sha256sum }}'
 
 - name: 'Extract Shibboleth IdP distribution'
   shell: >
@@ -71,7 +71,7 @@
   args:
     creates: '{{ shib_idp.home }}/views/intercept'
 
-- include: libs.yml
+- include_tasks: libs.yml
 
 - name: 'Set customised messages.properties'
   template:
@@ -554,7 +554,7 @@
   get_url:
     url: '{{ metadata_cert_url }}'
     dest: '{{ shib_idp.home }}/credentials/{{ metadata_cert_file_name }}'
-    sha256sum: '{{ metadata_cert_sha256sum }}'
+    checksum: 'sha256:{{ metadata_cert_sha256sum }}'
     force: yes
   when: metadata_cert_sha256sum is defined
 
@@ -589,7 +589,7 @@
     group: jetty
     mode: 0640
 
-- include: idp-credentials.yml
+- include_tasks: idp-credentials.yml
 
 - name: 'Fix IdP dir permissions'
   file:

--- a/tasks/jetty.yml
+++ b/tasks/jetty.yml
@@ -18,7 +18,7 @@
   get_url:
     url: '{{ urls.jetty.url }}'
     dest: '{{ jetty_dist_archive_path }}'
-    sha256sum: '{{ download.jetty.sha256sum }}'
+    checksum: 'sha256:{{ download.jetty.sha256sum }}'
 
 - name: 'Extract jetty distribution'
   shell: >

--- a/tasks/libs.yml
+++ b/tasks/libs.yml
@@ -11,7 +11,7 @@
   get_url:
     url: '{{ urls.dta_ssl.url }}'
     dest:  '{{ shib_idp.libs }}/jetty94-dta-ssl-{{ download.dta_ssl.version }}.jar'
-    sha256sum: '{{ download.dta_ssl.sha256sum }}'
+    checksum: 'sha256:{{ download.dta_ssl.sha256sum }}'
     owner: root
     group: jetty
     mode: 0640
@@ -26,7 +26,7 @@
   get_url:
     url: '{{ urls.logback_access.url }}'
     dest: '{{ shib_idp.libs }}/logback-access-{{ download.logback_access.version }}.jar'
-    sha256sum: '{{ download.logback_access.sha256sum }}'
+    checksum: 'sha256:{{ download.logback_access.sha256sum }}'
     owner: root
     group: jetty
     mode: 0640
@@ -41,7 +41,7 @@
   get_url:
     url: '{{ urls.logback_classic.url }}'
     dest: '{{ shib_idp.libs }}/logback-classic-{{ download.logback_classic.version }}.jar'
-    sha256sum: '{{ download.logback_classic.sha256sum }}'
+    checksum: 'sha256:`{{ download.logback_classic.sha256sum }}'
     owner: root
     group: jetty
     mode: 0640
@@ -56,7 +56,7 @@
   get_url:
     url: '{{ urls.logback_core.url }}'
     dest: '{{ shib_idp.libs }}/logback-core-{{ download.logback_core.version }}.jar'
-    sha256sum: '{{ download.logback_core.sha256sum }}'
+    checksum: 'sha256:{{ download.logback_core.sha256sum }}'
     owner: root
     group: jetty
     mode: 0640
@@ -71,7 +71,7 @@
   get_url:
     url: '{{ urls.jcl_over_slf4j.url }}'
     dest: '{{ shib_idp.libs }}/jcl-over-slf4j-{{ download.jcl_over_slf4j.version }}.jar'
-    sha256sum: '{{ download.jcl_over_slf4j.sha256sum }}'
+    checksum: 'sha256:{{ download.jcl_over_slf4j.sha256sum }}'
     owner: root
     group: jetty
     mode: 0640
@@ -86,7 +86,7 @@
   get_url:
     url: '{{ urls.slf4j_api.url }}'
     dest: '{{ shib_idp.libs }}/slf4j-api-{{ download.slf4j_api.version }}.jar'
-    sha256sum: '{{ download.slf4j_api.sha256sum }}'
+    checksum: 'sha256:{{ download.slf4j_api.sha256sum }}'
     owner: root
     group: jetty
     mode: 0640
@@ -101,7 +101,7 @@
   get_url:
     url: '{{ urls.aaf_shib_ext.url }}'
     dest: '{{ shib_idp.libs }}/aaf-shib-ext-{{ download.aaf_shib_ext.version }}.jar'
-    sha256sum: '{{ download.aaf_shib_ext.sha256sum }}'
+    checksum: 'sha256:{{ download.aaf_shib_ext.sha256sum }}'
     mode: 0640
     owner: root
     group: jetty
@@ -116,7 +116,7 @@
   get_url:
     url: '{{ urls.mysql_connector.url }}'
     dest: '{{ installer.path }}/mysql-connector-java-{{ download.mysql_connector.version }}.tar.gz'
-    sha256sum: '{{ download.mysql_connector.sha256sum }}'
+    checksum: 'sha256:{{ download.mysql_connector.sha256sum }}'
     owner: root
     group: jetty
     mode: 0640

--- a/tasks/system.yml
+++ b/tasks/system.yml
@@ -18,7 +18,7 @@
     state: permissive
   when: selinux_available.stat.exists == true
 
-- name: 'Install required packages'
+- name: 'Install required packages (Version 7 and 8)'
   yum:
     name:
       - java-11-openjdk-devel
@@ -28,7 +28,23 @@
       - chrony
       - ruby
     state: installed
-  when: patch_with=="yum"
+  when: (((ansible_distribution_major_version == "7") or 
+          (ansible_distribution_major_version == "8")) and 
+         (patch_with=="yum"))
+
+- name: 'Install required packages (Version 9)'
+  yum:
+    name:
+      - java-11-openjdk-devel
+      - mariadb-devel
+      - mariadb
+      - mariadb-server
+      - chrony
+      - ruby
+    state: installed
+    enablerepo: crb
+  when: ((ansible_distribution_major_version == "9") and
+         (patch_with=="yum"))
 
 - name: 'Install required packages - apt'
   apt:
@@ -56,6 +72,14 @@
       - python3-PyMySQL
     state: installed
   when: ((ansible_distribution_major_version == "8") and (patch_with=="yum"))
+
+- name: 'Install required packages - OS Version 9'
+  yum:
+    name:
+      - python3-cryptography
+      - python3-PyMySQL
+    state: installed
+  when: ((ansible_distribution_major_version == "9") and (patch_with=="yum"))
 
 - name: 'Install required packages - apt'
   apt:


### PR DESCRIPTION
… (#75)

* Feature shibv430 (#66)

* Update Shib and Jetty versions

* Temporarly set branch for testing

* Updated version numbers to 4.3.0

* Clean up

* Set repo to develop

---------



* Feature shibv430 (#70)

* Update Shib and Jetty versions

* Temporarly set branch for testing

* Updated version numbers to 4.3.0

* Clean up

* Set repo to develop

* replace sah256sum with checksum option for get_url

* Fixed typo in checksum type

* Fixed typo in checksum type

* Replace deprecated include statements with include_tasks

* Specific config for Centos 9

* Added Ububtu 22.04 as supported OS

* Use repo crb when installing mariadb-devel on Rocky/Centos 9 servers

---------



* Fixed surname in eduGAIN attribute filter

* Set branch to MASTER and updated version info

* Develop clone (#74)

* Feature shibv430 (#66)

* Update Shib and Jetty versions

* Temporarly set branch for testing

* Updated version numbers to 4.3.0

* Clean up

* Set repo to develop

---------



* Feature shibv430 (#70)

* Update Shib and Jetty versions

* Temporarly set branch for testing

* Updated version numbers to 4.3.0

* Clean up

* Set repo to develop

* replace sah256sum with checksum option for get_url

* Fixed typo in checksum type

* Fixed typo in checksum type

* Replace deprecated include statements with include_tasks

* Specific config for Centos 9

* Added Ububtu 22.04 as supported OS

* Use repo crb when installing mariadb-devel on Rocky/Centos 9 servers

---------



* Fixed surname in eduGAIN attribute filter

* Set branch to MASTER and updated version info

---------




---------